### PR TITLE
fix: add geometry and bbox to our one stac item

### DIFF
--- a/data/stac/haz_risk_severe2.json
+++ b/data/stac/haz_risk_severe2.json
@@ -7,6 +7,19 @@
     "https://stac-extensions.github.io/table/v1.2.0/schema.json"
   ],
   "id": "haz_risk_severe2",
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [-17.530915771, -34.834170003],
+        [-17.530915771, 27.3632],
+        [51.41303253200001, 27.3632],
+        [51.41303253200001, -34.834170003],
+        [-17.530915771, -34.834170003]
+      ]
+    ]
+  },
+  "bbox": [-17.530915771, -34.834170003, 51.41303253200001, 27.3632],
   "properties": {
     "datetime": "2024-06-27T21:58:17Z",
     "description": "Crop and livestock exposure data",


### PR DESCRIPTION
I left them off when I first made it, and looked them up from https://digital-atlas.s3.amazonaws.com/stac/public_stac

## Checklist

<!-- Feel free to remove any items that don't apply to your PR (e.g. small fixes may not require documentation updates). -->

- [x] Pre-commit hooks pass (`uv run prek run --all-files`)
- [x] Tests pass (`uv run pytest --integration`)
- [x] The PR's title is formatted per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
