### PR TITLE
feat: add frontend to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       - "5173:5173"
     volumes:
       - ./frontend/src:/app/src
-      - ./frontend/public:/app/public
       - ./data:/data 
     depends_on:
       - api

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,7 +5,6 @@ COPY package*.json ./
 RUN npm install
 
 COPY src ./src
-COPY public ./public
 COPY *.json ./
 COPY *.js ./
 COPY *.ts ./


### PR DESCRIPTION
- Adds Docker Compose support for the frontend with separate development and production builds, allowing it to run alongside the backend for local development.

- Note: GitHub Actions will need to be updated to use the correct environment build. Will create a separate ticket around this. 

- Closes: https://github.com/AdaptationAtlas/adaptation-atlas-assistant/issues/85#event-20770434033
