### PR TITLE
fix: redirect with base url

### DIFF
--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -11,7 +11,7 @@ export function Login() {
     e.preventDefault();
     try {
       await login(username, password);
-      window.location.href = '/';
+      window.location.href = import.meta.env.BASE_URL;
     } catch (err) {
       console.error('Login failed:', err);
     }


### PR DESCRIPTION
right now when deployed via github pages to https://adaptationatlas.github.io/adaptation-atlas-assistant/ — doing a login at the url  navigates to http://adaptationatlas.github.io/ which fails because that's not where the app is

this fixes that by using the base_url in vite.config.ts