### PR TITLE
feat: add dataset listing tool

### DIFF
--- a/backend/src/atlas_assistant/agent.py
+++ b/backend/src/atlas_assistant/agent.py
@@ -17,14 +17,14 @@ from langgraph.graph.state import CompiledStateGraph
 from .context import Context
 from .settings import Settings
 from .state import State
-from .tools.dataset import select_dataset
+from .tools.dataset import list_datasets, select_dataset
 from .tools.sql import execute_sql, generate_sql
 
 Agent = CompiledStateGraph[
     AgentState[None], Context, _InputAgentState, _OutputAgentState[None]
 ]
 
-TOOLS = [select_dataset, generate_sql, execute_sql]
+TOOLS = [list_datasets, select_dataset, generate_sql, execute_sql]
 
 
 def create_agent(settings: Settings) -> Agent:

--- a/backend/src/atlas_assistant/tools/dataset.py
+++ b/backend/src/atlas_assistant/tools/dataset.py
@@ -20,6 +20,28 @@ class SearchResult(BaseModel):
 
 
 @tool
+def list_datasets(runtime: ToolRuntime[Context, State]) -> Command[None]:
+    """Lists all datasets available to the assistant."""
+    settings = runtime.context.settings
+    embeddings = settings.get_embeddings()
+    dataset_descriptions = [
+        Metadata.model_validate(d).to_dataset().get_description()
+        for d in embeddings.get(include=["metadatas"])["metadatas"]
+    ]
+    return Command(
+        update={
+            "messages": [
+                ToolMessage(
+                    content=f"Got {len(dataset_descriptions)} with these descriptions:"
+                    "\n\n" + "- ".join(dataset_descriptions),
+                    tool_call_id=runtime.tool_call_id,
+                )
+            ],
+        }
+    )
+
+
+@tool
 def select_dataset(query: str, runtime: ToolRuntime[Context, State]) -> Command[None]:
     """Selects a dataset based on a user's query.
 

--- a/backend/tests/test_agent.py
+++ b/backend/tests/test_agent.py
@@ -2,22 +2,19 @@ import pytest
 from langchain_core.messages import HumanMessage
 
 import atlas_assistant.agent
-from atlas_assistant.agent import Agent
 from atlas_assistant.context import Context
 from atlas_assistant.settings import Settings
 
-pytestmark = pytest.mark.integration
 
-
-@pytest.fixture
-def agent(settings: Settings) -> Agent:
-    return atlas_assistant.agent.create_agent(settings)
-
-
-def test_kenya_crops(agent: Agent, settings: Settings) -> None:
+@pytest.mark.parametrize(
+    "query", ("What crops are being grown in Kenya?", "What datasets are available?")
+)
+@pytest.mark.integration
+def test_query(query: str, settings: Settings) -> None:
+    agent = atlas_assistant.agent.create_agent(settings)
     _ = agent.invoke(
         {
-            "messages": [HumanMessage("What crops are being grown in Kenya?")],
+            "messages": [HumanMessage(query)],
         },
         config={"configurable": {"thread_id": "test"}},
         context=Context(settings=settings),


### PR DESCRIPTION
A very simple tool, but something that I found myself asking, so might as well support it. Also, gives us a chance to parameterize the agent test.

<img width="3024" height="1720" alt="image" src="https://github.com/user-attachments/assets/707ce64b-e8e2-4cdd-87d4-7b3b1313256d" />

<img width="3024" height="1720" alt="image" src="https://github.com/user-attachments/assets/d855ff34-6281-40cc-a612-704a2f2933f2" />


## Checklist

- [x] Pre-commit hooks pass (`uv run prek run --all-files`)
- [x] Documentation updated
- [x] Tests pass (`uv run pytest --integration`)
- [x] The PR's title is formatted per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
