### PR TITLE
feat: add bar chart response message

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -126,6 +126,9 @@
                     },
                     {
                       "$ref": "#/components/schemas/AiResponseMessage"
+                    },
+                    {
+                      "$ref": "#/components/schemas/BarChartResponseMessage"
                     }
                   ],
                   "title": "Response Chat Chat Post"
@@ -178,6 +181,71 @@
         ],
         "title": "AiResponseMessage",
         "description": "The response from the AI"
+      },
+      "BarChartMetadata": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "x_column": {
+            "type": "string",
+            "title": "X Column"
+          },
+          "y_column": {
+            "type": "string",
+            "title": "Y Column"
+          },
+          "grouping_column": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grouping Column"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title",
+          "x_column",
+          "y_column",
+          "grouping_column"
+        ],
+        "title": "BarChartMetadata",
+        "description": "Data to create a bar chart"
+      },
+      "BarChartResponseMessage": {
+        "properties": {
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "thread_id": {
+            "type": "string",
+            "title": "Thread Id"
+          },
+          "type": {
+            "type": "string",
+            "const": "bar-chart",
+            "title": "Type",
+            "default": "bar-chart"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/BarChartMetadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "content",
+          "thread_id",
+          "metadata"
+        ],
+        "title": "BarChartResponseMessage",
+        "description": "The agent has created a bar chart and here it is.\n\nThe message content is the data as a JSON string."
       },
       "Body_login_token_post": {
         "properties": {

--- a/backend/src/atlas_assistant/api.py
+++ b/backend/src/atlas_assistant/api.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
 from contextlib import asynccontextmanager
 from typing import Annotated, Any, Literal
 
@@ -16,6 +17,8 @@ from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.errors import GraphRecursionError
 from langgraph.graph.message import BaseMessage
+from langgraph.graph.state import RunnableConfig
+from langgraph.types import StateSnapshot
 from pwdlib import PasswordHash
 from pydantic import BaseModel
 from starlette import status
@@ -24,7 +27,9 @@ from . import settings
 from .agent import Agent, create_agent
 from .context import Context
 from .settings import Settings
+from .state import BarChartMetadata
 
+logger = logging.getLogger(__name__)
 algorithm = "HS256"
 password_hash = PasswordHash.recommended()
 
@@ -128,6 +133,17 @@ class AiResponseMessage(ResponseMessage):
     """The reason why the agent stopped"""
 
 
+class BarChartResponseMessage(ResponseMessage):
+    """The agent has created a bar chart and here it is.
+
+    The message content is the data as a JSON string.
+    """
+
+    type: Literal["bar-chart"] = "bar-chart"
+
+    metadata: BarChartMetadata
+
+
 class Error(BaseModel):
     """An error response"""
 
@@ -194,7 +210,9 @@ async def login(
 
 
 @app.post(
-    "/chat", tags=["chat"], response_model=ToolResponseMessage | AiResponseMessage
+    "/chat",
+    tags=["chat"],
+    response_model=ToolResponseMessage | AiResponseMessage | BarChartResponseMessage,
 )
 async def chat(
     request: Request,
@@ -233,40 +251,59 @@ async def query_agent(
 
     Each message is a JSON object on a new line.
     """
+    config: RunnableConfig = {"configurable": {"thread_id": thread_id}}
     async for update in agent.astream(
         {"messages": [HumanMessage(content=query)]},
         stream_mode="updates",
-        config={"configurable": {"thread_id": thread_id}},
+        config=config,
         context=Context(settings=settings),
     ):
+        state = agent.get_state(config)
         for value in update.values():
             if messages := value.get("messages"):
                 for msg in messages:
                     if msg.content:
-                        response_message = create_response_message(msg, thread_id)
-                        if response_message:
+                        for response_message in create_response_messages(
+                            msg, thread_id, state
+                        ):
                             if event_stream:
                                 yield response_message.to_event_stream() + "\n\n"
                             else:
                                 yield response_message.model_dump_json() + "\n"
 
 
-def create_response_message(
+def create_response_messages(
     message: BaseMessage,
     thread_id: str,
-) -> ToolResponseMessage | AiResponseMessage | None:
+    state: StateSnapshot,
+) -> Sequence[ResponseMessage]:
     if isinstance(message, ToolMessage):
         assert isinstance(message.content, str)
-        return ToolResponseMessage(
+        tool_response_message = ToolResponseMessage(
             name=message.name,
             content=message.content,
             status=message.status,
             thread_id=thread_id,
         )
+        messages: list[ResponseMessage] = [tool_response_message]
+        if tool_response_message.name == "generate_bar_chart_metadata":
+            messages.append(
+                BarChartResponseMessage(
+                    content=state.values["data"],
+                    metadata=state.values["bar_chart_metadata"],
+                    thread_id=thread_id,
+                )
+            )
+        return messages
     elif isinstance(message, AIMessage):
         assert isinstance(message.content, str)
-        return AiResponseMessage(
-            content=message.content,
-            finish_reason=message.response_metadata["finish_reason"],
-            thread_id=thread_id,
-        )
+        return [
+            AiResponseMessage(
+                content=message.content,
+                finish_reason=message.response_metadata["finish_reason"],
+                thread_id=thread_id,
+            )
+        ]
+    else:
+        logger.warning(f"No response messages created for message: {message.to_json()}")
+        return []


### PR DESCRIPTION
Closes #111. Note that the frontend will need to be updated for the new message type (the first AI message in this screenshot is actually a bar chart message:

<img width="3024" height="1720" alt="image" src="https://github.com/user-attachments/assets/d9d3c46e-51ad-4459-a743-07fdfeae08af" />

Incidentally, here's the external-service bar chart that the agent generated a link to: 

<img src="https://quickchart.io/chart?c={type:%27bar%27,data:{labels:[%27Tea%27,%27Cattle-Tropical%27,%27Cattle-Highland%27,%27Maize%27,%27Banana%27,%27Goats-Tropical%27,%27Potato%27,%27Bean%27,%27Arabica-Coffee%27,%27Sweet%20Potato%27],datasets:[{label:%27Total%20Value%20(USD)%27,data:[26822200000,20025700000,6731090000,5344950000,4158400000,4094400000,3636280000,3530150000,1963960000,1907860000]}]}}" />

## Checklist

<!-- Feel free to remove any items that don't apply to your PR (e.g. small fixes may not require documentation updates). -->

- [x] Pre-commit hooks pass (`uv run prek run --all-files`)
- [x] Documentation updated
- [x] Tests pass (`uv run pytest --integration`)
- [x] The PR's title is formatted per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
