### PR TITLE
fix: set auto approve in TF workflow

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -143,7 +143,7 @@ jobs:
         id: apply
         run: |
           set -e
-          terraform apply -no-color -input=false -var-file=${{ env.TFVARS_FILE }} | tee apply.txt
+          terraform apply -no-color -input=false -auto-approve -var-file=${{ env.TFVARS_FILE }} | tee apply.txt
           echo "stdout<<EOF" >> $GITHUB_OUTPUT
           cat apply.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Missing flag slipped by me: https://github.com/AdaptationAtlas/adaptation-atlas-assistant/actions/runs/19685777671/job/56390853545

Lock removed from local

## Checklist

<!-- Feel free to remove any items that don't apply to your PR (e.g. small fixes may not require documentation updates). -->

- [x] Pre-commit hooks pass (`uv run prek run --all-files`)
- [ ] Documentation updated
- [ ] Tests pass (`uv run pytest --integration`)
- [x] The PR's title is formatted per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
