### PR TITLE
build: use verified domain SES Identity

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -27,6 +27,7 @@ jobs:
       TFVARS_FILE: ${{ vars.TFVARS_FILE || 'tfvars/dev.tfvars' }}
       TF_VAR_mistral_api_key: ${{ secrets.TF_VAR_MISTRAL_API_KEY }}
       TF_VAR_jwt_key: ${{ secrets.TF_VAR_JWT_KEY }}
+      TF_VAR_email_source_arn: ${{ vars.TF_VAR_EMAIL_SOURCE_ARN }}
     defaults:
       run:
         working-directory: terraform/aws
@@ -121,6 +122,7 @@ jobs:
       TFVARS_FILE: ${{ vars.TFVARS_FILE || 'tfvars/dev.tfvars' }}
       TF_VAR_mistral_api_key: ${{ secrets.TF_VAR_MISTRAL_API_KEY }}
       TF_VAR_jwt_key: ${{ secrets.TF_VAR_JWT_KEY }}
+      TF_VAR_email_source_arn: ${{ vars.TF_VAR_EMAIL_SOURCE_ARN }}
     defaults:
       run:
         working-directory: terraform/aws

--- a/terraform/aws/cognito.tf
+++ b/terraform/aws/cognito.tf
@@ -1,8 +1,3 @@
-# Verified SES Identity is required when using email MFA, cannot use Cognito default
-resource "aws_ses_email_identity" "email_mfa" {
-  email = var.mfa_sender_email
-}
-
 resource "aws_cognito_user_pool" "atlas_pool" {
   name = "atlas-backend"
 
@@ -13,7 +8,8 @@ resource "aws_cognito_user_pool" "atlas_pool" {
 
   email_configuration {
     email_sending_account = "DEVELOPER"
-    source_arn            = aws_ses_email_identity.email_mfa.arn
+    source_arn            = var.email_source_arn
+    from_email_address    = var.from_email_address
   }
   email_mfa_configuration {}
 

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -81,10 +81,17 @@ variable "api_image_tag" {
   EOT
 }
 
-variable "mfa_sender_email" {
+variable "email_source_arn" {
   type        = string
-  default     = "ali@developmentseed.org"
   description = <<-EOT
-  Used to create + manage an SES Identity for MFA emails
+  Verified email or domain SES Identity to use for automated Cognito emails
+  EOT
+}
+
+variable "from_email_address" {
+  type        = string
+  default     = "no-reply@ds.io"
+  description = <<-EOT
+  Email From address to use for automated Cognito emails
   EOT
 }


### PR DESCRIPTION
See [thread](https://github.com/AdaptationAtlas/adaptation-atlas-assistant/issues/78#issuecomment-3583253203) for context.

SES is now in production mode in development account ([case](https://757082729759-tgzkl2j2.support.console.aws.amazon.com/support/home?region=us-east-1#/case/?displayId=176419665800031&language=en)) and the `ds.io` domain has been added as a verified Identity.

This PR modifies the Cognito email config to use the externally managed Identity

## Checklist

<!-- Feel free to remove any items that don't apply to your PR (e.g. small fixes may not require documentation updates). -->

- [x] Pre-commit hooks pass (`uv run prek run --all-files`)
- [ ] Documentation updated
- [ ] Tests pass (`uv run pytest --integration`)
- [x] The PR's title is formatted per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
