### PR TITLE
fix: add BASE_URL to path

### DIFF
--- a/frontend/src/components/Charts/Map.tsx
+++ b/frontend/src/components/Charts/Map.tsx
@@ -43,7 +43,8 @@ export const MapChart = ({
     useEffect(() => {
         // sample geojson data selected & downloaded from: https://geojson-maps.kyd.au/
         // the data was also reduced to retain minimal properties
-        fetch('/data/african-nations-reduced.geojson')
+        const geoJsonPath = `${import.meta.env.BASE_URL}data/african-nations-reduced.geojson`;
+        fetch(geoJsonPath)
             .then((response) => response.json())
             .then((data) => setGeoData(data as NationsGeoJSON))
             .catch((error) => console.error('Error loading GeoJSON:', error));


### PR DESCRIPTION
The path to the geojson needs the `BASE_URL` reference!

```sh
curl -I https://adaptationatlas.github.io/data/african-nations-reduced.geojson
```
Results in **404**

```sh
curl -I https://adaptationatlas.github.io/adaptation-atlas-assistant/data/african-nations-reduced.geojson
```
Results in **200**

## Checklist

<!-- Feel free to remove any items that don't apply to your PR (e.g. small fixes may not require documentation updates). -->

- [X] The PR's title is formatted per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
