### PR TITLE
fix: split pages deploy into two steps

### DIFF
--- a/.github/workflows/frontend-pages.yaml
+++ b/.github/workflows/frontend-pages.yaml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -50,14 +50,17 @@ jobs:
           VITE_COGNITO_CLIENT_ID: ${{ vars.VITE_COGNITO_CLIENT_ID }}
         run: npm run build
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: frontend/dist
 
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
We're getting strange errors on deploy: https://github.com/AdaptationAtlas/adaptation-atlas-assistant/actions/runs/20072247487/job/57577423574#logs. Most other projects I have split the pages deploy into two steps, so I copy that pattern in hopes of correcting the error.

## Checklist

<!-- Feel free to remove any items that don't apply to your PR (e.g. small fixes may not require documentation updates). -->

- [x] Pre-commit hooks pass (`uv run prek run --all-files`)
- [x] Tests pass (`uv run pytest --integration`)
- [x] The PR's title is formatted per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
