### PR TITLE
fix: return none if there's no data returned

### DIFF
--- a/backend/src/atlas_assistant/tools/sql.py
+++ b/backend/src/atlas_assistant/tools/sql.py
@@ -118,6 +118,11 @@ def generate_table(query: str, runtime: ToolRuntime[Context, State]) -> Command[
             "re-generating the SQL with `group by` or `distinct`."
         )
         data = None
+    elif len(data_frame) == 0:
+        content_parts.append(
+            f"Returned data had {len(data_frame)} rows. No data was returned."
+        )
+        data = None
     else:
         content_parts += [
             "Data returned:",


### PR DESCRIPTION
This should fix #182. cc @bjyberg 

Before:

<img alt="Screenshot 2025-12-16 at 05-39-21 Adaptation Atlas Assistant" src="https://github.com/user-attachments/assets/6becc771-b5a1-479e-87e2-fa4df7659061" />

After:

<img alt="Screenshot 2025-12-16 at 05-38-34 Adaptation Atlas Assistant" src="https://github.com/user-attachments/assets/6ffd3c12-8f70-4449-911c-139e67bfb5b2" />

## Checklist

- [x] Pre-commit hooks pass (`uv run prek run --all-files`)
- [x] Tests pass (`uv run pytest --integration`)
- [x] The PR's title is formatted per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
