### PR TITLE
fix: modfy mfa for account recovery + SES Identity pre-transition

### DIFF
--- a/terraform/aws/cognito.tf
+++ b/terraform/aws/cognito.tf
@@ -3,15 +3,12 @@ resource "aws_cognito_user_pool" "atlas_pool" {
 
   auto_verified_attributes = ["email"]
   deletion_protection      = "ACTIVE"
-  mfa_configuration        = "ON"
+  mfa_configuration        = "OPTIONAL"
   username_attributes      = ["email"]
 
-  email_configuration {
-    email_sending_account = "DEVELOPER"
-    source_arn            = var.email_source_arn
-    from_email_address    = var.from_email_address
+  software_token_mfa_configuration {
+    enabled = true
   }
-  email_mfa_configuration {}
 
   admin_create_user_config {
     allow_admin_create_user_only = true

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -90,21 +90,6 @@ variable "api_image_tag" {
   EOT
 }
 
-variable "email_source_arn" {
-  type        = string
-  description = <<-EOT
-  Verified email or domain SES Identity to use for automated Cognito emails
-  EOT
-}
-
-variable "from_email_address" {
-  type        = string
-  default     = "no-reply@ds.io"
-  description = <<-EOT
-  Email From address to use for automated Cognito emails
-  EOT
-}
-
 variable "embeddings_directory" {
   type        = string
   default     = null


### PR DESCRIPTION
Following up from earlier doscovery on account recovery with MFA → https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-mfa.html#user-pool-settings-mfa-prerequisites

Amazon does not allow use of one verification method for both MFA + password reset, and SMS isn't cheap. 

Additionally reduces urgency on https://github.com/AdaptationAtlas/adaptation-atlas-assistant/issues/178 by moving enabled method to software token

## Checklist

<!-- Feel free to remove any items that don't apply to your PR (e.g. small fixes may not require documentation updates). -->

- [ ] Pre-commit hooks pass (`uv run prek run --all-files`)
- [ ] Documentation updated
- [ ] Tests pass (`uv run pytest --integration`)
- [ ] The PR's title is formatted per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
