### PR TITLE
chore: fix the link to the acknowledgements image

### DIFF
--- a/frontend/src/components/Acknowledgements.tsx
+++ b/frontend/src/components/Acknowledgements.tsx
@@ -17,7 +17,7 @@ export function Acknowledgements({ className }: AcknowledgementsProps) {
 
             <div className={styles.logoContainer}>
                 <img
-                    src="/data/image.png"
+                    src={`${import.meta.env.BASE_URL}data/image.png`}
                     alt="CGIAR Climate Action"
                     className={styles.logo}
                 />


### PR DESCRIPTION
<!--
Please describe what your pull request does in plain language.
Include any screenshots that are instructive to a reviewer, and any special instructions to test beyond automated tests.
Link in any issues that are closed by this PR with "closing keywords", e.g. `Closes #42`.
-->
The current image used under the Acknowledgements is currently broken:
<img width="1378" height="755" alt="Screenshot 2025-12-18 at 9 41 03 AM" src="https://github.com/user-attachments/assets/fdedf087-296f-40da-98a3-5caca41cbd52" />

The path needs to reference the HOST BASE_URL.

## Checklist

<!-- Feel free to remove any items that don't apply to your PR (e.g. small fixes may not require documentation updates). -->

- [ ] Pre-commit hooks pass (`uv run prek run --all-files`)
- [ ] Documentation updated
- [ ] Tests pass (`uv run pytest --integration`)
- [x] The PR's title is formatted per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
